### PR TITLE
Habilita folding en lista de secciones

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -4,3 +4,6 @@ language = "en"
 multilingual = false
 src = "src"
 title = "ASEIC"
+
+[output.html.fold]
+enable = true


### PR DESCRIPTION
Este cambio provoca que las secciones anidadas dentro del índice tengan que ser explícitamente abiertas, mejorando la legibilidad.