### PR TITLE
cambio: corringe link de Telegram de Fabián Montero

### DIFF
--- a/src/representacion_estudiantil.md
+++ b/src/representacion_estudiantil.md
@@ -4,7 +4,7 @@
 La Junta Directiva para el año 2022 se conforma por las siguientes personas:
 
 - [Viviana Villalobos Valverde](https://t.me/Vivi1007) (Presidencia)
-- [Fabián Montero Villalobos](https://t.me/fabianmv) (Vicepresidencia)
+- [Fabián Montero Villalobos](https://t.me/fabianmontero) (Vicepresidencia)
 - [Ignacio Grané Rojas](https://t.me/Ignaciograne) (Secretaría general)
 - [Alejandro Díaz Pereira](https://t.me/adiazp) (Secretaría de Finanzas)
 - [Alejandro José Soto Chacón](https://t.me/soto3442) (Secretaría de Asunto Académicos)

--- a/src/representacion_estudiantil.md
+++ b/src/representacion_estudiantil.md
@@ -24,7 +24,7 @@ La Junta Directiva para el año 2022 se conforma por las siguientes personas:
 - [Jorge Luis Guillén Campos](https://t.me/j_guillen)
 
 ### Suplentes
-- [Fabián Montero Villalobos](https://t.me/fabianmv)
+- [Fabián Montero Villalobos](https://t.me/fabianmontero)
 - [Alejandro Díaz Pereira](https://t.me/adiazp)
 - [Ignacio Vargas Campos](https://t.me/zkwinkle)
 - [Gabs Chaves León](https://t.me/gachle)


### PR DESCRIPTION
Este cambio actualiza el link de telegram de Fabián Montero. Actualmente estaba el viejo, pero este es el nuevo.